### PR TITLE
Bump ant from 1.10.5 to 1.10.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.10.5</version>
+      <version>1.10.11</version>
     </dependency>
   </dependencies> 
 


### PR DESCRIPTION
Bumps ant from 1.10.5 to 1.10.11.

---
updated-dependencies:
- dependency-name: org.apache.ant:ant dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>